### PR TITLE
Jcornevin/jkr 15388/add timeout to transient errors

### DIFF
--- a/facebookads/__init__.py
+++ b/facebookads/__init__.py
@@ -21,7 +21,7 @@
 from facebookads.session import FacebookSession
 from facebookads.api import FacebookAdsApi
 
-__version__ = '2.10.2.1'
+__version__ = '2.10.1+work4.1'
 __all__ = [
     'session',
     'objects',

--- a/facebookads/__init__.py
+++ b/facebookads/__init__.py
@@ -21,7 +21,7 @@
 from facebookads.session import FacebookSession
 from facebookads.api import FacebookAdsApi
 
-__version__ = '2.10.1'
+__version__ = '2.10.2'
 __all__ = [
     'session',
     'objects',

--- a/facebookads/__init__.py
+++ b/facebookads/__init__.py
@@ -21,7 +21,7 @@
 from facebookads.session import FacebookSession
 from facebookads.api import FacebookAdsApi
 
-__version__ = '2.10.2'
+__version__ = '2.10.2.1'
 __all__ = [
     'session',
     'objects',

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -129,10 +129,12 @@ class FacebookResponse(object):
             is_transient = error.get('is_transient', False)
             error_message = error.get('message', False)
 
-            if self.is_failure() and not is_transient and error_message in self.TRANSIENT_ERROR_MESSAGES:
-                error['is_transient'] = True
-                json_body['error'] = error
-                self._body = json.dumps(json_body)
+            for transient_error_message in self.TRANSIENT_ERROR_MESSAGES:
+                if self.is_failure() and not is_transient and transient_error_message in error_message:
+                    error['is_transient'] = True
+                    json_body['error'] = error
+                    self._body = json.dumps(json_body)
+                    break
         except AttributeError:  # not a dict, we don't know much
             return
 

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -51,7 +51,10 @@ api module contains classes that make http requests to Facebook's graph API.
 class FacebookResponse(object):
     """Encapsulates an http response from Facebook's Graph API."""
 
-    TRANSIENT_ERROR_MESSAGE = 'An unknown error occurred'
+    TRANSIENT_ERROR_MESSAGES = [
+        'An unknown error occurred',
+        'This could happen if a dependent request failed or the entire request timed out.'
+    ]
 
     def __init__(self, body=None, http_status=None, headers=None, call=None):
         """Initializes the object's internal data.
@@ -126,7 +129,7 @@ class FacebookResponse(object):
             is_transient = error.get('is_transient', False)
             error_message = error.get('message', False)
 
-            if self.is_failure() and not is_transient and error_message == self.TRANSIENT_ERROR_MESSAGE:
+            if self.is_failure() and not is_transient and error_message in self.TRANSIENT_ERROR_MESSAGES:
                 error['is_transient'] = True
                 json_body['error'] = error
                 self._body = json.dumps(json_body)

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -129,12 +129,15 @@ class FacebookResponse(object):
             is_transient = error.get('is_transient', False)
             error_message = error.get('message', False)
 
-            for transient_error_message in self.TRANSIENT_ERROR_MESSAGES:
-                if self.is_failure() and not is_transient and transient_error_message in error_message:
-                    error['is_transient'] = True
-                    json_body['error'] = error
-                    self._body = json.dumps(json_body)
-                    break
+            if (
+                self.is_failure()
+                and not is_transient
+                and error_message
+                and any((transient_message in error_message for transient_message in self.TRANSIENT_ERROR_MESSAGES))
+            ):
+                error['is_transient'] = True
+                json_body['error'] = error
+                self._body = json.dumps(json_body)
         except AttributeError:  # not a dict, we don't know much
             return
 

--- a/facebookads/apiconfig.py
+++ b/facebookads/apiconfig.py
@@ -20,6 +20,6 @@
 
 ads_api_config = {
   'API_VERSION': 'v2.10',
-  'SDK_VERSION': 'v2.10.2.1',
+  'SDK_VERSION': 'v2.10.1+work4.1',
   'STRICT_MODE': False
 }

--- a/facebookads/apiconfig.py
+++ b/facebookads/apiconfig.py
@@ -20,6 +20,6 @@
 
 ads_api_config = {
   'API_VERSION': 'v2.10',
-  'SDK_VERSION': 'v2.10.1.1',
+  'SDK_VERSION': 'v2.10.2',
   'STRICT_MODE': False
 }

--- a/facebookads/apiconfig.py
+++ b/facebookads/apiconfig.py
@@ -20,6 +20,6 @@
 
 ads_api_config = {
   'API_VERSION': 'v2.10',
-  'SDK_VERSION': 'v2.10.2',
+  'SDK_VERSION': 'v2.10.2.1',
   'STRICT_MODE': False
 }

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -637,14 +637,19 @@ class FacebookResponseTestCase(unittest.TestCase):
         self.assertTrue(resp.is_transient())
 
     def test_is_transient_by_message(self):
-        resp = api.FacebookResponse(
-            http_status=500, call={},
-            body=json.dumps({"error": {"is_transient": False, "message": "An unknown error occurred"}})
-        )
-        self.assertTrue(resp.is_transient())
-        self.assertEqual(
-            resp._body, json.dumps({"error": {"is_transient": True, "message": "An unknown error occurred"}}))
-        self.assertTrue(resp.error().api_transient_error())
+        messages = [
+            'An unknown error occurred',
+            'This could happen if a dependent request failed or the entire request timed out.'
+        ]
+        for message in messages:
+            resp = api.FacebookResponse(
+                http_status=500, call={},
+                body=json.dumps({"error": {"is_transient": False, "message": message}})
+            )
+            self.assertTrue(resp.is_transient())
+            self.assertEqual(
+                resp._body, json.dumps({"error": {"is_transient": True, "message": message}}))
+            self.assertTrue(resp.error().api_transient_error())
 
     def test_evaluate_if_transient_not_json(self):
         resp = api.FacebookResponse(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebookads'
-PACKAGE_VERSION = '2.10.2.1'
+PACKAGE_VERSION = '2.10.1+work4.1'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-ads-sdk'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebookads'
-PACKAGE_VERSION = '2.10.1.1'
+PACKAGE_VERSION = '2.10.2'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-ads-sdk'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebookads'
-PACKAGE_VERSION = '2.10.2'
+PACKAGE_VERSION = '2.10.2.1'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-ads-sdk'


### PR DESCRIPTION
↖️ https://work4labs.atlassian.net/browse/JKR-15388

also see https://github.com/Work4Labs/work4us/pull/13736 

## Goal:
Mark timeout error as transient so that they can be retried.

-----
run `python -m facebookads.test.unit` to test