### PR TITLE
BAT-8508 Migrate to CircleCi 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,12 @@ jobs:
   python-3.4:
     <<: *shared
     docker:
-      - image: circleci/python::3.4-jessie-node
+      - image: circleci/python:3.4-jessie-node
 
   python-3.6:  # Not specified in tox.ini
     <<: *shared
     docker:
-      - image: circleci/python::3.6-jessie-node
+      - image: circleci/python:3.6-jessie-node
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,11 @@ shared: &shared
       - checkout
       # Define config in CircleCi's project settings → Environment Variables
       - run: echo \{\"app_id\":\"$FB_APP_ID\",\"app_secret\":\"$FB_APP_SECRET\",\"act_id\":\"act_$FB_ACCOUNT_ID\",\"page_id\":\"$FB_PAGE_ID\",\"access_token\":\"$FB_ACCESS_TOKEN\",\"business\":\"$FB_BUSINESS_ID\",\"sec_business\":\"$FB_BUSINESS_ID_BIS\",\"sec_act_id\":\"act_$FB_ACCOUNT_ID_BIS\"\} > config.json
-      - run: python setup.py install
-      - run: python -m facebook_business.test.unit
-      - run: python -m facebook_business.test.integration
+      # Cheapo virtualenv, CCi images use the circleci user so no writing to the root site-packages
+      - run: virtualenv venv
+      - run: venv/bin/python setup.py install
+      - run: venv/bin/python -m facebook_business.test.unit
+      - run: venv/bin/python -m facebook_business.test.integration
 
 jobs:
   # Note: no 3.3 image from CCi readily available – not that we care about that version anyway.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+# We could use an image with pyenv & tox, but it's just as much work as doing a matrix build.
+# Sorry tox.ini...
+version: 2
+
+shared: &shared
+    steps:
+      - checkout
+      # Define config in CircleCi's project settings → Environment Variables
+      - run: echo \{\"app_id\":\"$FB_APP_ID\",\"app_secret\":\"$FB_APP_SECRET\",\"act_id\":\"act_$FB_ACCOUNT_ID\",\"page_id\":\"$FB_PAGE_ID\",\"access_token\":\"$FB_ACCESS_TOKEN\",\"business\":\"$FB_BUSINESS_ID\",\"sec_business\":\"$FB_BUSINESS_ID_BIS\",\"sec_act_id\":\"act_$FB_ACCOUNT_ID_BIS\"\} > config.json
+      - run: python setup.py install
+      - run: python -m facebook_business.test.unit
+      - run: python -m facebook_business.test.integration
+
+jobs:
+  # Note: no 3.3 image from CCi readily available – not that we care about that version anyway.
+  python-2.7:
+    <<: *shared
+    docker:
+      - image: circleci/python:2.7-jessie-node
+
+  python-3.4:
+    <<: *shared
+    docker:
+      - image: circleci/python::3.4-jessie-node
+
+  python-3.6:  # Not specified in tox.ini
+    <<: *shared
+    docker:
+      - image: circleci/python::3.6-jessie-node
+
+
+workflows:
+  version: 2
+  default_build:
+    jobs:
+      - python-2.7
+      - python-3.4
+      - python-3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,23 @@ jobs:
       - image: circleci/python:3.6-jessie-node
 
 
-workflows:
-  version: 2
-  default_build:
+
+all_jobs: &all_jobs
     jobs:
       - python-2.7
       - python-3.4
       - python-3.6
+
+workflows:
+  version: 2
+  default_build:
+    <<: *all_jobs
+  nightly:
+    <<: *all_jobs
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
CCi 1.0 inferred a lot of stuff, and we had setup the remainder in "override" commands in the web UI. CCi 2.0 has neither features, so we need to explicitly define those steps.

Furthermore, while `tox` is great, testing on multiple Python versions isn't great for a Docker-based system. So we test on multiple images instead.