### PR TITLE
add too many data to transient errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	python3 -m facebook_business.test.unit

--- a/facebook_business/__init__.py
+++ b/facebook_business/__init__.py
@@ -21,7 +21,7 @@
 from facebook_business.session import FacebookSession
 from facebook_business.api import FacebookAdsApi
 
-__version__ = '7.0.4+work4'
+__version__ = '7.0.4.1+work4'
 __all__ = [
     'session',
     'objects',

--- a/facebook_business/__init__.py
+++ b/facebook_business/__init__.py
@@ -21,7 +21,7 @@
 from facebook_business.session import FacebookSession
 from facebook_business.api import FacebookAdsApi
 
-__version__ = '7.0.5.1+work4'
+__version__ = '7.0.6+work4'
 __all__ = [
     'session',
     'objects',

--- a/facebook_business/__init__.py
+++ b/facebook_business/__init__.py
@@ -21,7 +21,7 @@
 from facebook_business.session import FacebookSession
 from facebook_business.api import FacebookAdsApi
 
-__version__ = '7.0.4+work4'
+__version__ = '7.0.5+work4'
 __all__ = [
     'session',
     'objects',

--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -914,7 +914,7 @@ class Cursor(object):
 
         if 'paging' in response and 'next' in response['paging']:
             self._path = response['paging']['next']
-            self.params = []
+            self.params = {}
         else:
             # Indicate if this was the last page
             self._finished_iteration = True

--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -54,7 +54,8 @@ class FacebookResponse(object):
     TRANSIENT_ERROR_MESSAGES = [
         'An unknown error occurred',
         'Sorry, something went wrong',
-        'This could happen if a dependent request failed or the entire request timed out.'
+        'This could happen if a dependent request failed or the entire request timed out.',
+        'Please reduce the amount of data',
     ]
 
     def __init__(self, body=None, http_status=None, headers=None, call=None):

--- a/facebook_business/test/unit.py
+++ b/facebook_business/test/unit.py
@@ -718,7 +718,8 @@ class FacebookResponseTestCase(unittest.TestCase):
             </body>
             </html>
             """,
-            'This could happen if a dependent request failed or the entire request timed out.'
+            'This could happen if a dependent request failed or the entire request timed out.',
+            "Please reduce the amount of data you're asking for, then retry your request",
         ]
         for message in messages:
             resp = api.FacebookResponse(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebook_business'
-PACKAGE_VERSION = '7.0.4+work4'
+PACKAGE_VERSION = '7.0.4.1+work4'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-business-sdk'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebook_business'
-PACKAGE_VERSION = '7.0.5.1+work4'
+PACKAGE_VERSION = '7.0.6+work4'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-business-sdk'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebook_business'
-PACKAGE_VERSION = '7.0.4+work4'
+PACKAGE_VERSION = '7.0.5+work4'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-business-sdk'


### PR DESCRIPTION
cf https://work4labs.atlassian.net/browse/JKR-19616

```
    ~/Dev/facebook-python-ads-sdk    master !4 ?1  make test                                                                                                                                                              ✔  facebook-python-ads-sdk   11:54:26 
python3 -m facebook_business.test.unit
..................../Users/jolancornevin/Dev/facebook-python-ads-sdk/facebook_business/api.py:960: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  isinstance(value, (collections.Mapping, collections.Sequence, bool))
........................
----------------------------------------------------------------------
Ran 44 tests in 0.007s
```